### PR TITLE
Disable the autostart of xdebug as it does several thousand requests to y

### DIFF
--- a/lib/Package/xdebug.pm
+++ b/lib/Package/xdebug.pm
@@ -81,7 +81,7 @@ sub install {
     $self->shell({silent => 0}, "echo '[xdebug]' >> /tmp/50-extension-" . $self->shortname() . ".ini");
     $self->shell({silent => 0}, "echo 'xdebug.remote_enable=on' >> /tmp/50-extension-" . $self->shortname() . ".ini");
     $self->shell({silent => 0}, "echo 'xdebug.default_enable=on' >> /tmp/50-extension-" . $self->shortname() . ".ini");
-    $self->shell({silent => 0}, "echo 'xdebug.remote_autostart=on' >> /tmp/50-extension-" . $self->shortname() . ".ini");
+    $self->shell({silent => 0}, "echo 'xdebug.remote_autostart=off' >> /tmp/50-extension-" . $self->shortname() . ".ini");
     $self->shell({silent => 0}, "echo 'xdebug.remote_port=9000' >> /tmp/50-extension-" . $self->shortname() . ".ini");
     $self->shell({silent => 0}, "echo 'xdebug.remote_host=localhost' >> /tmp/50-extension-" . $self->shortname() . ".ini");
     $self->shell({silent => 0}, "echo 'xdebug.profiler_enable_trigger=1' >> /tmp/50-extension-" . $self->shortname() . ".ini");


### PR DESCRIPTION
Disable the autostart of xdebug as it does several thousand requests to your local machine if you don't have a sever running.
It will slow down requests heavily and throw errors like this on BSD machines:
21.09.11 22:39:40.000 kernel: Limiting closed port RST response from 252 to 250 packets per second
