### PR TITLE
turn on DTrace

### DIFF
--- a/lib/Package/php5.pm
+++ b/lib/Package/php5.pm
@@ -103,7 +103,8 @@ sub configure_flags {
 		'--with-mysql=mysqlnd',
 		'--with-mysqli=mysqlnd',
 		'--with-pdo-mysql=mysqlnd',
-		'--enable-pcntl'
+		'--enable-pcntl',
+		'--enable-dtrace'
 	);
 
 	push @extension_flags, $self->dependency_extension_flags(%args);


### PR DESCRIPTION
5.4.0 is the first 'stable' php release to include DTrace support in php core.  This would be very nice to have (especially since OS X is one of the most accessible dev platforms with DTrace).
