### PR TITLE
APC 3.1.13

### DIFF
--- a/lib/Package/apc.pm
+++ b/lib/Package/apc.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base qw(Package::peclbase);
 
-our $VERSION = '3.1.12';
+our $VERSION = '3.1.13';
 
 sub init {
     my $self = shift;


### PR DESCRIPTION
3.1.12 is a bad build. 3.1.13 fixes common segfault. Issue: https://github.com/liip/php-osx/issues/45
