### PR TITLE
Adds APC compatibility for PHP5.5 alpha2

### DIFF
--- a/lib/Package/apc.pm
+++ b/lib/Package/apc.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base qw(Package::peclbase);
 
-our $VERSION = '3.1.12';
+our $VERSION = '3.1.14';
 
 sub init {
     my $self = shift;
@@ -46,9 +46,11 @@ sub packagesrcdir {
 sub extension_ini{
     my ($self, $dst) = @_;
     $self->shell({silent => 0}, "echo ';extension=" . $dst . lc($self->shortname()) . ".so' > /tmp/50-extension-" . $self->shortname() . ".ini");
-    # some default value
+    # some default values
     $self->shell({silent => 0}, "echo ';[APC]' >> /tmp/50-extension-" . $self->shortname() . ".ini");
-    $self->shell({silent => 0}, "echo ';apc.enabled = off' >> /tmp/50-extension-" . $self->shortname() . ".ini");
+    $self->shell({silent => 0}, "echo ';apc.enabled = 1' >> /tmp/50-extension-" . $self->shortname() . ".ini");
+    $self->shell({silent => 0}, "echo ';apc.shm_segments = 1' >> /tmp/50-extension-" . $self->shortname() . ".ini");
+    $self->shell({silent => 0}, "echo ';apc.shm_size = 128M' >> /tmp/50-extension-" . $self->shortname() . ".ini");
 }
 
 return 1;


### PR DESCRIPTION
Update APC to 3.1.14 to add compatibility with PHP 5.5 alpha2.
Also added the two most changed variables to the generated ini file, commented out by default.
