### PR TITLE
Downgrade to APC 3.1.13

### DIFF
--- a/lib/Package/apc.pm
+++ b/lib/Package/apc.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base qw(Package::peclbase);
 
-our $VERSION = '3.1.14';
+our $VERSION = '3.1.13';
 
 sub init {
     my $self = shift;


### PR DESCRIPTION
APC 3.1.14 was removed from the PECL list due to some major memory issues
https://bugs.php.net/bug.php?id=64116#1359652340
