### PR TITLE
Update phpredis to 4.3.0 for PHP 7.0

### DIFF
--- a/lib/Package/redis.pm
+++ b/lib/Package/redis.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base qw(Package::peclbase);
 
-our $VERSION = '3.1.2';
+our $VERSION = '4.2.0';
 
 sub init {
     my $self = shift;

--- a/lib/Package/redis.pm
+++ b/lib/Package/redis.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base qw(Package::peclbase);
 
-our $VERSION = '4.2.0';
+our $VERSION = '4.3.0';
 
 sub init {
     my $self = shift;


### PR DESCRIPTION
Hitting issues where Redis 3.1.2 is missing some redis features, so this is suggestion to bump to 4.2.0.
Alternatives would be 4.1.1, or 3.1.6.