### PR TITLE
Update phpredis, phpmemcached & xdebug for PHP 7.3

### DIFF
--- a/lib/Package/memcached.pm
+++ b/lib/Package/memcached.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base qw(Package::peclbase);
 
-our $VERSION = '3.0.3';
+our $VERSION = '3.1.3';
 
 sub init {
 	my $self = shift;

--- a/lib/Package/redis.pm
+++ b/lib/Package/redis.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base qw(Package::peclbase);
 
-our $VERSION = '3.1.2';
+our $VERSION = '4.3.0';
 
 sub init {
     my $self = shift;

--- a/lib/Package/xdebug.pm
+++ b/lib/Package/xdebug.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base qw(Package);
 
-our $VERSION = '2.7.0';
+our $VERSION = '2.7.1';
 
 sub base_url {
     return "http://xdebug.org/files/";

--- a/lib/Package/xdebug.pm
+++ b/lib/Package/xdebug.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use base qw(Package);
 
-our $VERSION = '2.6.1';
+our $VERSION = '2.7.0';
 
 sub base_url {
     return "http://xdebug.org/files/";

--- a/lib/Package/xdebug.pm
+++ b/lib/Package/xdebug.pm
@@ -6,7 +6,6 @@ use warnings;
 use base qw(Package);
 
 our $VERSION = '2.7.2';
-
 sub base_url {
     return "http://xdebug.org/files/";
 }


### PR DESCRIPTION
@chregu Unsure how you want this, but here are some packages updates that from the looks of it needs version bump for PHP 7.3 compat.